### PR TITLE
make tiles clickable on ios

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,11 +49,11 @@ function sketch(p) {
     drawGrid();
   };
 
-  // mouseClicked and touchStarted defined so interactions
+  // mouseClicked and touchEnded defined so interactions
   // work on both desktop and mobile
   p.mouseClicked = () => interactWithTileAt(p.mouseX, p.mouseY);
 
-  p.touchStarted = () => {
+  p.touchEnded = () => {
     const { x, y } = p.touches.at(-1);
     interactWithTileAt(x, y);
   };

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,10 @@ import { PATH_COLORS, BACKGROUND_COLOR, GLOW_COLOR } from "./colors";
 import { CURVED_CONNECTIONS } from "./connections";
 
 const canvasWrapper = document.getElementById("p5sketch");
+// Mark the element that contains the sketch as clickable so Safari on iOS will
+// respect touch-action: manipulation and disable double tap to zoom as per
+// https://bugs.webkit.org/show_bug.cgi?id=149854#c25
+canvasWrapper.onclick = () => {};
 new p5(sketch, canvasWrapper);
 
 function sketch(p) {

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,22 @@ function sketch(p) {
     drawGrid();
   };
 
+  // FIXIT: logic duplicated
+  p.touchStarted = () => {
+    if (!gameEnded) {
+      const { x, y } = p.touches.at(-1);
+      const c = p.floor(x / tileSize);
+      const r = p.floor(y / tileSize);
+      if (grid._isOnBoard(r, c)) {
+        grid.rotateSquare(r, c);
+      }
+    }
+
+    checkLevelFinished();
+    console.log(grid.squares.map((row) => row.map((sq) => sq.rotation)));
+    drawGrid();
+  };
+
   // TODO: write tests for this
   function checkLevelFinished() {
     for (const row of grid.squares) {

--- a/src/index.js
+++ b/src/index.js
@@ -45,24 +45,17 @@ function sketch(p) {
     drawGrid();
   };
 
-  p.mouseClicked = () => {
-    if (!gameEnded) {
-      const c = p.floor(p.mouseX / tileSize);
-      const r = p.floor(p.mouseY / tileSize);
-      if (grid._isOnBoard(r, c)) {
-        grid.rotateSquare(r, c);
-      }
-    }
+  // mouseClicked and touchStarted defined so interactions
+  // work on both desktop and mobile
+  p.mouseClicked = () => interactWithTileAt(p.mouseX, p.mouseY);
 
-    checkLevelFinished();
-    console.log(grid.squares.map((row) => row.map((sq) => sq.rotation)));
-    drawGrid();
+  p.touchStarted = () => {
+    const { x, y } = p.touches.at(-1);
+    interactWithTileAt(x, y);
   };
 
-  // FIXIT: logic duplicated
-  p.touchStarted = () => {
+  function interactWithTileAt(x, y) {
     if (!gameEnded) {
-      const { x, y } = p.touches.at(-1);
       const c = p.floor(x / tileSize);
       const r = p.floor(y / tileSize);
       if (grid._isOnBoard(r, c)) {
@@ -73,7 +66,7 @@ function sketch(p) {
     checkLevelFinished();
     console.log(grid.squares.map((row) => row.map((sq) => sq.rotation)));
     drawGrid();
-  };
+  }
 
   // TODO: write tests for this
   function checkLevelFinished() {


### PR DESCRIPTION
p5 fires touch events if you define `mousePressed` but not `mouseClicked`, but I want the event to fire only when the mouse is released.